### PR TITLE
Fixed app name in notification

### DIFF
--- a/normcap/handlers/notification_handler.py
+++ b/normcap/handlers/notification_handler.py
@@ -13,6 +13,7 @@ from normcap.common.data_model import NormcapData
 from normcap.handlers.abstract_handler import AbstractHandler
 from normcap import __version__
 
+
 class NotificationHandler(AbstractHandler):
     def handle(self, request: NormcapData) -> NormcapData:
         """Trigger system notification when ocr is done.

--- a/normcap/handlers/notification_handler.py
+++ b/normcap/handlers/notification_handler.py
@@ -11,7 +11,7 @@ from importlib_resources import files  # type: ignore
 # Own
 from normcap.common.data_model import NormcapData
 from normcap.handlers.abstract_handler import AbstractHandler
-
+from normcap import __version__
 
 class NotificationHandler(AbstractHandler):
     def handle(self, request: NormcapData) -> NormcapData:
@@ -82,6 +82,7 @@ class NotificationHandler(AbstractHandler):
         notification = Notify()
         notification.title = title
         notification.message = text
+        notification.application_name = 'NormCap ' + __version__
         if icon_path:
             notification.icon = icon_path
         notification.send(block=False)


### PR DESCRIPTION
For Issue #27 This fixes the issue with the wrong application name displayed in the notification panel (Windows).
