### PR TITLE
handle BaseWindow.hideEvent exception for non-macOS systems

### DIFF
--- a/src/normcap/gui/base_window.py
+++ b/src/normcap/gui/base_window.py
@@ -198,8 +198,11 @@ class BaseWindow(QtWidgets.QMainWindow):
         return super().changeEvent(event)
 
     def hideEvent(self, _) -> None:
-        if self.macos_border_window:
-            self.macos_border_window.hide()
+        try:
+            if self.macos_border_window:
+                self.macos_border_window.hide()
+        except AttributeError:
+            logger.debug("No such attribute: self.macos_border_window")
 
     ##################
     # Adjust UI


### PR DESCRIPTION
I was experiencing the following exception on my Arch setup using GNOME 40:

```
15:57:14 - INFO    - normcap.app            - L:37  - Starting Normcap v0.2.5
15:57:15 - INFO    - normcap.utils          - L:178 - Searching tesseract languages 
15:57:19 - ERROR   - normcap.utils          - L:288 - Uncaught exception! Quitting NormCap!
Traceback (most recent call last):
  File "/home/erfan/.local/lib/python3.9/site-packages/normcap/gui/base_window.py", line 201, in hideEvent
    if self.macos_border_window:
AttributeError: 'MainWindow' object has no attribute 'macos_border_window'
```

It turns out that by just returning and doing nothing at `BaseWindow.hideEvent` everything goes right; so I added this exception catching clause.