### PR TITLE
Add meta info to appimage

### DIFF
--- a/build.py
+++ b/build.py
@@ -301,6 +301,21 @@ def patch_briefcase_appimage():
     patch_file(file_path=file_path, insert_above=insert_above, lines=lines_to_insert)
 
 
+def add_metainfo_to_appimage():
+    """Copy metainfo file with info for appimage hub."""
+    metainfo = Path.cwd() / "src" / "normcap" / "resources" / "metainfo"
+    target_path = (
+        Path.cwd()
+        / "linux"
+        / "appimage"
+        / "NormCap"
+        / "NormCap.AppDir"
+        / "usr"
+        / "share"
+    )
+    shutil.copy(metainfo, target_path / "metainfo")
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1] == "download-tessdata":
         download_tessdata()

--- a/build.py
+++ b/build.py
@@ -76,6 +76,7 @@ EXCLUDE_FROM_APP_PACKAGES = [
 
 
 def get_version() -> str:
+    """Get versions string from pyproject.toml."""
     with open("pyproject.toml", encoding="utf8") as toml_file:
         pyproject_toml = toml.load(toml_file)
     return pyproject_toml["tool"]["poetry"]["version"]
@@ -377,7 +378,7 @@ if __name__ == "__main__":
         cmd("briefcase create")
         cmd("briefcase build")
         cmd("briefcase package")
-        cmd(f"mv linux/*.AppImage linux/NormCap-{get_version()}-x86_64.AppImage")
+        cmd(f"mv -f linux/*.AppImage linux/NormCap-{get_version()}-x86_64.AppImage")
 
     else:
         raise ValueError("Unknown Operating System.")

--- a/build.py
+++ b/build.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import List
 
 import briefcase  # type: ignore
+import toml
 
 platform_str = sys.platform.lower()
 
@@ -72,6 +73,12 @@ EXCLUDE_FROM_APP_PACKAGES = [
     "/tests/",
     "docs",
 ]
+
+
+def get_version() -> str:
+    with open("pyproject.toml", encoding="utf8") as toml_file:
+        pyproject_toml = toml.load(toml_file)
+    return pyproject_toml["tool"]["poetry"]["version"]
 
 
 def cmd(cmd_str: str):
@@ -331,7 +338,7 @@ if __name__ == "__main__":
         cmd("briefcase build")
         patch_windows_installer()
         cmd("briefcase package")
-        cmd("mv windows/*.msi windows/NormCap-Windows.msi")
+        cmd(f"mv windows/*.msi windows/NormCap-{get_version()}-Windows.msi")
 
     elif platform_str.lower().startswith("darwin"):
         app_dir = (
@@ -352,7 +359,7 @@ if __name__ == "__main__":
         rm_recursive(directory=app_dir / "PySide2", exclude=EXCLUDE_FROM_PYSIDE2)
         cmd("briefcase build")
         cmd("briefcase package macos app --no-sign")
-        cmd("mv macOS/*.dmg macOS/NormCap-MacOS.dmg")
+        cmd(f"mv macOS/*.dmg macOS/NormCap-{get_version()}-MacOS.dmg")
 
     elif platform_str.lower().startswith("linux"):
         print(f"Current User ID: {os.getuid()}")  # type: ignore
@@ -370,7 +377,7 @@ if __name__ == "__main__":
         cmd("briefcase create")
         cmd("briefcase build")
         cmd("briefcase package")
-        cmd("mv linux/*.AppImage linux/NormCap-Linux.AppImage")
+        cmd(f"mv linux/*.AppImage linux/NormCap-{get_version()}-x86_64.AppImage")
 
     else:
         raise ValueError("Unknown Operating System.")

--- a/src/normcap/gui/update_check.py
+++ b/src/normcap/gui/update_check.py
@@ -47,7 +47,7 @@ class UpdateChecker(QtCore.QObject):
 
         try:
             if self.packaged:
-                match = re.search(r'title="v(\d+\.\d+\.\d+.*)"|$', text)
+                match = re.search(r"download/v(\d+\.\d+\.\d+.*)/|$", text)
                 if match and match.group(1):
                     newest_version = match.group(1)
             else:

--- a/src/normcap/resources/metainfo
+++ b/src/normcap/resources/metainfo
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>eu.dynobo.normcap</id>
+
+  <name>NormCap</name>
+  <summary>OCR powered screen-capture tool to capture information instead of images.</summary>
+
+  <metadata_license>MIT</metadata_license>
+  <project_license>AGPL-3.0-or-later</project_license>
+
+  <description>
+    <p>
+      <em>
+      </em>Features:<em>
+    </em>
+  </p>
+  <p>
+    - On-screen recognition of selected text in many languages<br>
+    - Multi monitor support, incl. HDPI displays<br>
+    - Support for Wayland and X11<br>
+    - Parsing the text (optional, on by default)<br>
+    - Stay in system tray (optional)
+  </p>
+  <p>
+    <em>
+    </em>Basic usage:<em>
+  </em>
+</p>
+<p>
+  - Start NormCap<br>
+  - Select a region on screen with your mouse to perform text recognition<br>
+  - The text will be copied to the clipboard. Paste it anywhere with e.g. <code>ctrl + v</code><br>
+  - Press <code>&lt;esc&gt;</code> key to abort a capture and quit the application.
+</p>
+</description>
+
+<launchable type="desktop-id">eu.dynobo.normcap.desktop</launchable>
+<screenshots>
+  <screenshot type="default">
+    <image>https://github.com/dynobo/normcap/raw/main/assets/screenshot.png</image>
+  </screenshot>
+</screenshots>
+</component>

--- a/src/tests/test_update_check.py
+++ b/src/tests/test_update_check.py
@@ -9,8 +9,8 @@ from normcap.gui import update_check
 @pytest.mark.parametrize("packaged", [True, False])
 def test_update_checker_new_version(monkeypatch, qtbot, packaged):
     """Retrieve version information from github."""
-    checker = update_check.UpdateChecker(None, packaged=packaged)
     monkeypatch.setattr(update_check, "__version__", "0.0.0")
+    checker = update_check.UpdateChecker(None, packaged=packaged)
     with qtbot.waitSignal(checker.com.on_version_retrieved) as result:
         checker.check()
     version = result.args[0]
@@ -24,8 +24,8 @@ def test_update_checker_new_version(monkeypatch, qtbot, packaged):
 @pytest.mark.parametrize("packaged", [True, False])
 def test_update_checker_no_new_version(monkeypatch, qtbot, packaged):
     """Retrieve version information from github."""
-    checker = update_check.UpdateChecker(None, packaged=packaged)
     monkeypatch.setattr(update_check, "__version__", "9.9.9")
+    checker = update_check.UpdateChecker(None, packaged=packaged)
     with qtbot.waitSignal(
         checker.com.on_version_retrieved, raising=False, timeout=2000
     ) as result:


### PR DESCRIPTION
The info should be rendered in appimagehub, once normcap got published there (see AppImage/appimage.github.io#2789).