### PR TITLE
fix FAQ link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [PyPi](https://pypi.org/project/normcap) |
 [Releases](https://github.com/dynobo/normcap/releases) |
 [Changelog](https://github.com/dynobo/normcap/blob/main/CHANGELOG.md) |
-[FAQs](https://github.com/dynobo/normcap/blob/main/FAQ.md)
+[FAQs](https://dynobo.github.io/normcap/#faqs)
 
 [![Screencast](https://user-images.githubusercontent.com/11071876/123133596-3107d080-d450-11eb-8451-6dcebb7876ad.gif)](https://raw.githubusercontent.com/dynobo/normcap/main/assets/normcap.gif)
 


### PR DESCRIPTION
Hi @dynobo, I noticed that the FAQ link in the README points to a file that doesn't exist. Accordingly, here is my attempt to point to the respective section in the current documentation. Hope this helps, cheers :relaxed: 