### PR TITLE
build: pin manylinux image tag to fix segfault #534

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -117,7 +117,7 @@ jobs:
       # Build test packages
       - name: Test build briefcase package
         shell: bash -l {0}
-        run: hatch run python bundle/build.py --framework=briefcase --dev
+        run: hatch run bundle --dev
       - name: Print briefcase log in case of error
         if: failure()
         shell: bash -l {0}
@@ -176,7 +176,7 @@ jobs:
           python-version: "3.10"
       - name: Build package briefcase
         shell: bash -l {0}
-        run: hatch run python bundle/build.py --framework=briefcase
+        run: hatch run bundle
       - name: Draft release
         if: github.repository == 'dynobo/normcap'
         uses: ncipollo/release-action@v1

--- a/bundle/platforms/macos_briefcase.py
+++ b/bundle/platforms/macos_briefcase.py
@@ -4,6 +4,8 @@ import platform
 import shutil
 from pathlib import Path
 
+from retry import retry
+
 from platforms.utils import BuilderBase
 
 
@@ -82,6 +84,7 @@ class MacBriefcase(BuilderBase):
         )
         shutil.copy(tesseract_source, tesseract_target)
 
+    @retry(tries=5, delay=1, backoff=2)
     def install_system_deps(self) -> None:
         self.run(cmd="brew install tesseract")
         self.run(cmd="brew install dylibbundler")

--- a/bundle/platforms/utils.py
+++ b/bundle/platforms/utils.py
@@ -70,8 +70,15 @@ class BuilderBase(ABC):
             cwd=self.PROJECT_PATH,
         )
 
+    def clean(self) -> None:
+        build_dir = self.PROJECT_PATH / "build"
+        if build_dir.exists():
+            print(f"Removing old build directory {build_dir.resolve()}")  # noqa: T201
+            shutil.rmtree(build_dir, ignore_errors=True)
+
     def create(self) -> None:
         """Run all steps to build prebuilt packages."""
+        self.clean()
         self.download_tessdata()
         self.install_system_deps()
         self.compile_locales()

--- a/bundle/platforms/utils.py
+++ b/bundle/platforms/utils.py
@@ -15,8 +15,6 @@ from typing import Optional, Union
 import toml
 from retry import retry
 
-# TODO: Add retries to all downloads
-
 
 class BuilderBase(ABC):
     """Create a prebuilt package."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ locales-compile = "python bundle/l10n.py"
 locales-update = "python bundle/l10n.py --update-all"
 create-locale = "python bundle/l10n.py --create-new"
 version = "tbump {args:current-version}"
+bundle = ["locales-compile", "python bundle/build.py --framework=briefcase {args}"]
 
 [[tool.hatch.envs.all.matrix]]
 python = ["3.9", "3.10", "3.11"]
@@ -275,7 +276,7 @@ requires = ["std-nslog==1.0.0"]
 [tool.briefcase.app.normcap.linux.appimage]
 template = "https://github.com/beeware/briefcase-linux-appimage-template"
 template_branch = "v0.3.16"
-manylinux = "manylinux_2_28"
+manylinux = "manylinux2014_x86_64"
 system_requires = [
   "wget",
   "tesseract",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,7 +276,7 @@ requires = ["std-nslog==1.0.0"]
 [tool.briefcase.app.normcap.linux.appimage]
 template = "https://github.com/beeware/briefcase-linux-appimage-template"
 template_branch = "v0.3.16"
-manylinux = "manylinux2014_x86_64"
+manylinux = "manylinux_2_28"
 system_requires = [
   "wget",
   "tesseract",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,6 +277,7 @@ requires = ["std-nslog==1.0.0"]
 template = "https://github.com/beeware/briefcase-linux-appimage-template"
 template_branch = "v0.3.16"
 manylinux = "manylinux_2_28"
+manylinux_image_tag="2023-09-16-066b049"
 system_requires = [
   "wget",
   "tesseract",


### PR DESCRIPTION
in an issue in the manylinux repo it was stated, that starting with tags starting from 2023-09-17 a segfault can occure. And indeed: pinning to an older tag solved the segfault in normcap, too.