### PR TITLE
fix: transpose selected region correctly #397

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
 
 # Changelog
 
-## v0.5.0beta2 (not yet released)
+## v0.5.0 (not yet released)
 
 - All: Fix issue where introduction window was still visible on the screen capture UI.
   ([#536 comment](https://github.com/dynobo/normcap/issues/536#issuecomment-1752110232))
@@ -16,6 +16,10 @@
   replaced by `"`. (You can still use "raw"-mode to leave them intact.)
 - Windows, macOS: Fix notifications not clickable in "raw"-Mode.
   ([#438 comment](https://github.com/dynobo/normcap/issues/438#issuecomment-1752175090))
+- Linux: Fig segfault in AppImage.
+  ([#543](https://github.com/dynobo/normcap/issues/534))
+- Linux: Fix incorrect selection when display scaling is active.
+  ([#397](https://github.com/dynobo/normcap/issues/397))
 - Linux: Add support for using `xclip` to copy result to clipboard. This seems more
   stable on Wayland systems than `wl-clipboard`, at least until compatibility with
   latest Gnome updates is restored.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,8 +172,11 @@ def run_normcap(monkeypatch, qapp, basic_cli_args):
     yield _run_normcap
 
     for tray in trays:
+        tray._close_windows()
         tray._exit_application(delay=0)
         tray.deleteLater()
+
+    QtCore.QTimer.singleShot(0, QtCore.QCoreApplication.processEvents)
 
 
 @pytest.fixture()

--- a/tests/integration/testcases/data.py
+++ b/tests/integration/testcases/data.py
@@ -16,6 +16,20 @@ class TestCase:
     _image: QtGui.QImage | None = None
 
     @property
+    def _screen_size(self) -> QtCore.QSize:
+        app = QtWidgets.QApplication.instance()
+        if isinstance(app, QtGui.QGuiApplication):
+            return app.primaryScreen().size() * self._device_pixel_ratio
+        raise TypeError("Could not detect QGuiApplication")
+
+    @property
+    def _device_pixel_ratio(self) -> float:
+        app = QtWidgets.QApplication.instance()
+        if isinstance(app, QtGui.QGuiApplication):
+            return app.primaryScreen().devicePixelRatio()
+        raise TypeError("Could not detect QGuiApplication")
+
+    @property
     def image(self) -> QtGui.QImage:
         if not self._image:
             self._image = QtGui.QImage(self.image_path)
@@ -24,13 +38,13 @@ class TestCase:
     @property
     def screenshot(self) -> QtGui.QImage:
         """Provides image drawn on colored canvas with the size of the screen."""
-        if self.image.size().toTuple() > self.screen_size.toTuple():
+        if self.image.size().toTuple() > self._screen_size.toTuple():
             raise ValueError(
                 f"{self.image_path.name} is too large "
-                f"for screen size {self.screen_size.toTuple}!"
+                f"for screen size {self._screen_size.toTuple}!"
             )
 
-        pixmap = QtGui.QPixmap(self.screen_size)
+        pixmap = QtGui.QPixmap(self._screen_size)
         pixmap.fill(QtCore.Qt.GlobalColor.darkCyan)
 
         with QtGui.QPainter(pixmap) as painter:
@@ -38,17 +52,11 @@ class TestCase:
         return pixmap.toImage()
 
     @property
-    def screen_size(self) -> QtCore.QSize:
-        app = QtWidgets.QApplication.instance()
-        if isinstance(app, QtGui.QGuiApplication):
-            return app.primaryScreen().size()
-        raise TypeError("Could not detect QGuiApplication")
-
-    @property
     def coords(self) -> tuple[QtCore.QPoint, QtCore.QPoint]:
+        size = self.image.size() / self._device_pixel_ratio
         return (
             QtCore.QPoint(1, 1),
-            QtCore.QPoint(self.image.width() - 1, self.image.height() - 1),
+            QtCore.QPoint(size.width() - 1, size.height() - 1),
         )
 
 

--- a/tests/tests_clipboard/test_wlclipboard.py
+++ b/tests/tests_clipboard/test_wlclipboard.py
@@ -35,6 +35,9 @@ def test_wlcopy_is_compatible(
     assert wlclipboard.WlCopyHandler().is_compatible == result
 
 
+# ONHOLD: Check if wl-copy works on Gnome 45 without the need to click on notification.
+# see https://github.com/bugaevc/wl-clipboard/issues/168
+@pytest.mark.skipif(True, reason="Buggy in Gnome 45")
 @pytest.mark.skipif(not shutil.which("wl-copy"), reason="Needs wl-copy")
 @pytest.mark.skipif(sys.platform != "linux", reason="Linux specific test")
 def test_wlcopy_copy():
@@ -53,6 +56,7 @@ def test_wlcopy_copy():
     assert text == clipped
 
 
+@pytest.mark.skipif(True, reason="Buggy in Gnome 45")
 @pytest.mark.skipif(sys.platform == "linux", reason="Non-Linux specific test")
 def test_wlcopy_copy_on_non_linux():
     result = wlclipboard.WlCopyHandler().copy(text="this is a test")

--- a/tests/tests_gui/test_loading_indicator.py
+++ b/tests/tests_gui/test_loading_indicator.py
@@ -93,7 +93,7 @@ def test_frame_count_progresses(monkeypatch, qtbot):
 
     # WHEN showing the indicator with a certain framerate and waiting x seconds
     assert indicator.counter == 0
-    indicator.framerate = 30
+    indicator.framerate = 120
     window.show()
     indicator.show()
     qtbot.wait(1500)

--- a/tests/tests_gui/test_window.py
+++ b/tests/tests_gui/test_window.py
@@ -48,10 +48,9 @@ def test_window_get_scale_factor(
         screenshot=image,
     )
 
-    # WHEN the window is shown
+    # WHEN the window is created
     win = window.Window(screen=screen, settings=temp_settings, parent=None)
     win.resize(QtCore.QSize(*window_size))
-    qtbot.addWidget(win)
 
     # THEN the expected scaling factor should be calculated
     assert win._get_scale_factor() == expected_factor
@@ -71,10 +70,9 @@ def test_window_get_scale_factor_raises_if_missing(qtbot, temp_settings):
         screenshot=image,
     )
 
-    # WHEN the window is shown
+    # WHEN the window is created
     #   and the screenshot is not available (anymore)
     win = window.Window(screen=screen, settings=temp_settings, parent=None)
-    qtbot.addWidget(win)
     win.screen_.screenshot = None
 
     # THEN an exception should be raised when trying to calculate the scale factor

--- a/tests/tests_gui/test_window.py
+++ b/tests/tests_gui/test_window.py
@@ -25,7 +25,7 @@ def test_move_active_window_to_position_raises_on_non_linux():
 
 @pytest.mark.gui()
 @pytest.mark.parametrize(
-    ("img_size", "screen_size", "expected_factor"),
+    ("img_size", "window_size", "expected_factor"),
     [
         ((600, 400), (600, 400), 1.0),
         ((300, 200), (600, 400), 0.5),
@@ -33,7 +33,7 @@ def test_move_active_window_to_position_raises_on_non_linux():
     ],
 )
 def test_window_get_scale_factor(
-    qtbot, temp_settings, img_size, screen_size, expected_factor
+    qtbot, temp_settings, img_size, window_size, expected_factor
 ):
     # GIVEN a screenshot of a certain size
     #   and a certain (Qt) screen size
@@ -42,14 +42,15 @@ def test_window_get_scale_factor(
         device_pixel_ratio=1.0,
         left=0,
         top=0,
-        right=screen_size[0] - 1,
-        bottom=screen_size[1] - 1,
+        right=window_size[0] - 1,
+        bottom=window_size[1] - 1,
         index=0,
         screenshot=image,
     )
 
     # WHEN the window is shown
     win = window.Window(screen=screen, settings=temp_settings, parent=None)
+    win.resize(QtCore.QSize(*window_size))
     qtbot.addWidget(win)
 
     # THEN the expected scaling factor should be calculated


### PR DESCRIPTION
On wayland, window and screen dimensions reported by Qt differ if "normal" scaling is used, or the experimental fractional scaling (scale-monitor-framebuffer). To transpose the selected region from window position to screenshot position robustly, it's better to use Qt's window dimensions as reference instead of the Qt's screen dimensions.