### PR TITLE
fix(screengrab): use more robust args to test grim

### DIFF
--- a/normcap/screengrab/utils.py
+++ b/normcap/screengrab/utils.py
@@ -90,15 +90,14 @@ def has_dbus_portal_support() -> bool:
 def has_grim_support() -> bool:
     if not shutil.which("grim"):
         return False
+
     with tempfile.TemporaryDirectory() as temp_dir:
         try:
             completed_proc = subprocess.run(
                 [  # noqa: S607
                     "grim",
-                    "-g",
-                    "0,0 5x5",
-                    "-l",
-                    "0",
+                    "-s",
+                    "0.01",
                     f"{temp_dir}{os.pathsep}normcap_test.png",
                 ],
                 shell=False,  # noqa: S603


### PR DESCRIPTION
Screenshotting a small region of the screen to test grim with a minimum delay turned out to be not robust, because a pre-defined region might not be part of the display.

Therefor we switched to grab the whole screen for testing, but scale the result to a tiny picture to keep the delay low.