### PR TITLE
Fixed issue #600 - leftover dbus screenshot file gets deleted

### DIFF
--- a/normcap/screengrab/handlers/dbus_portal.py
+++ b/normcap/screengrab/handlers/dbus_portal.py
@@ -4,6 +4,7 @@ import logging
 import random
 import re
 import sys
+import os
 from typing import Optional
 from urllib.parse import urlparse
 
@@ -197,7 +198,13 @@ def _synchronized_capture(interactive: bool) -> QtGui.QImage:
         raise error
 
     uri = result[0]
-    return QtGui.QImage(urlparse(uri).path)
+    image_path = urlparse(uri).path
+    image = QtGui.QImage(urlparse(uri).path)
+    try:
+        os.remove(image_path)
+    except:
+        logger.warn(f"Failed to remove leftover screenshot file \"{image_path}\"!")
+    return image
 
 
 def is_compatible() -> bool:

--- a/normcap/screengrab/handlers/dbus_portal.py
+++ b/normcap/screengrab/handlers/dbus_portal.py
@@ -199,7 +199,7 @@ def _synchronized_capture(interactive: bool) -> QtGui.QImage:
 
     uri = result[0]
     image_path = urlparse(uri).path
-    image = QtGui.QImage(urlparse(uri).path)
+    image = QtGui.QImage(image_path)
     try:
         os.remove(image_path)
     except:


### PR DESCRIPTION
Using the tool on Linux with Wayland on DEs like Gnome or Plasma keeps screenshot file in the user's Pictures directory after each use. This is an annoying issue and it's currently open - #600, so I went and fixed it. It was quite a simple change, just a few lines of code. I tested that on Fedora 40 with KDE Plasma 6.0 and it worked without an issue. For this to work with Flatpak, additional permission needs to be allowed for the app to have write access in `~/Pictures`. I don't think there is a better solution to this problem, as the dbus portal doesn't give any control over the placement of the screenshot file it creates.