### PR TITLE
fix(gui): enable workaround for setFullScreen() for all wayland DEs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,10 @@
 
 # Changelog
 
+## v0.5.8 (2024-05-19)
+
+- Linux: Next try to fix issue on Ubuntu/Unity where the window doesn't show up. ([#651](https://github.com/dynobo/normcap/pull/651))
+
 ## v0.5.7 (2024-05-18)
 
 - All: Add french translation. Thanks, [@NathanBnm](https://github.com/NathanBnm)! ([#648](https://github.com/dynobo/normcap/pull/648))

--- a/normcap/gui/window.py
+++ b/normcap/gui/window.py
@@ -162,7 +162,7 @@ class Window(QtWidgets.QMainWindow):
             self.setMinimumSize(self.geometry().size())
             self.setMaximumSize(self.geometry().size())
 
-        if system_info.desktop_environment == DesktopEnvironment.UNITY:
+        if system_info.display_manager_is_wayland():
             # For unknown reason .showFullScreen() on Ubuntu 24.04 does not show the
             # window. Showing the Window in normal state upfront seems to help.
             # (It seems like .setWindowState(WindowFullScreen) should not be set before


### PR DESCRIPTION
Another try to fix #642. Enabling the workaround for all Wayland DEs. Hopefully, it doesn't have to bad side effects on untested setups.