### PR TITLE
Add a note on additional libraries that might be needed for the AppImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ take a look at the [FAQs](https://dynobo.github.io/normcap/#faqs) or
   
   Note: On some systems, you may need to install additional packages, such as `libxcrypt-compat` or the `FUSE` library for the AppImage to run. See [FAQ](https://dynobo.github.io/normcap/faqs/#linux-appimage-error-while-loading-shared-libraries-libcryptso1) for more details.
 
-</details>
-
 - [`normcap` @ AUR](https://aur.archlinux.org/packages/normcap) (Arch/Manjaro)
 - [com.github.dynobo.normcap @ FlatHub](https://flathub.org/apps/details/com.github.dynobo.normcap)
   (FlatPak)

--- a/README.md
+++ b/README.md
@@ -36,13 +36,10 @@ take a look at the [FAQs](https://dynobo.github.io/normcap/#faqs) or
   (Installer)
 
 #### Linux
-<details>
-
-<summary> <a href="https://github.com/dynobo/normcap/releases/download/v0.5.8/NormCap-0.5.8-x86_64.AppImage">NormCap-0.5.8-x86_64.AppImage</a> (Binary) </summary>
-
-| :warning: NOTE          |
-|:---------------------------|
-| On some systems, you may need to install additional packages, such as `libxcrypt-compat` or the `FUSE` library, to ensure proper functionality of the AppImage. For more information, please refer to our [FAQ](https://dynobo.github.io/normcap/faqs/#linux-appimage-error-while-loading-shared-libraries-libcryptso1).|
+- [NormCap-0.5.8-x86_64.AppImage](https://github.com/dynobo/normcap/releases/download/v0.5.8/NormCap-0.5.8-x86_64.AppImage)
+  (Binary)
+  
+  Note: On some systems, you may need to install additional packages, such as `libxcrypt-compat` or the `FUSE` library for the AppImage to run. See [FAQ](https://dynobo.github.io/normcap/faqs/#linux-appimage-error-while-loading-shared-libraries-libcryptso1) for more details.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,16 @@ take a look at the [FAQs](https://dynobo.github.io/normcap/#faqs) or
   (Installer)
 
 #### Linux
+<details>
 
-- [NormCap-0.5.8-x86_64.AppImage](https://github.com/dynobo/normcap/releases/download/v0.5.8/NormCap-0.5.8-x86_64.AppImage)
-  (Binary)
+<summary> <a href="https://github.com/dynobo/normcap/releases/download/v0.5.8/NormCap-0.5.8-x86_64.AppImage">NormCap-0.5.8-x86_64.AppImage</a> (Binary) </summary>
+
+| :warning: NOTE          |
+|:---------------------------|
+| On some systems, you may need to install additional packages, such as `libxcrypt-compat` or the `FUSE` library, to ensure proper functionality of the AppImage. For more information, please refer to our [FAQ](https://dynobo.github.io/normcap/faqs/#linux-appimage-error-while-loading-shared-libraries-libcryptso1).|
+
+</details>
+
 - [`normcap` @ AUR](https://aur.archlinux.org/packages/normcap) (Arch/Manjaro)
 - [com.github.dynobo.normcap @ FlatHub](https://flathub.org/apps/details/com.github.dynobo.normcap)
   (FlatPak)


### PR DESCRIPTION
This MR expands the AppImage link in the readme with a note suggesting that other runtime libraries might be needed and points to our FAQ.

Please suggest ideas for formatting and wording.

Closes https://github.com/dynobo/normcap/issues/654