### PR TITLE
feat: support portable package for Windows

### DIFF
--- a/bundle/build.py
+++ b/bundle/build.py
@@ -4,6 +4,7 @@ import sys
 from platforms.linux_briefcase import LinuxBriefcase
 from platforms.macos_briefcase import MacBriefcase
 from platforms.windows_briefcase import WindowsBriefcase
+from platforms.windows_briefcase_zip import WindowsBriefcaseZip
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -16,16 +17,19 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    builders = []
     if sys.platform == "win32":
-        builder = WindowsBriefcase
+        builders.append(WindowsBriefcase)
+        builders.append(WindowsBriefcaseZip)
 
     elif sys.platform == "darwin":
-        builder = MacBriefcase
+        builders.append(MacBriefcase)
 
     elif sys.platform == "linux":
-        builder = LinuxBriefcase
+        builders.append(LinuxBriefcase)
 
     else:
         raise RuntimeError(f"Unknown platform '{sys.platform}'.")
 
-    builder().create()
+    for builder in builders:
+        builder().create()

--- a/bundle/platforms/windows_briefcase_zip.py
+++ b/bundle/platforms/windows_briefcase_zip.py
@@ -1,5 +1,7 @@
 """Run adjustments while packaging with briefcase during CI/CD."""
 
+from pathlib import Path
+
 from platforms.windows_briefcase  import WindowsBriefcase
 
 
@@ -15,4 +17,15 @@ class WindowsBriefcaseZip(WindowsBriefcase):
         self._patch_main_cpp()
         self.run(cmd="briefcase build windows VisualStudio", cwd=self.PROJECT_PATH)
         self._patch_windows_installer()
+        portable_flag_file = (
+            self.PROJECT_PATH
+            / "build"
+            / "normcap"
+            / "windows"
+            / "visualstudio"
+            / "x64"
+            / "Release"
+            / "portable"
+        )
+        Path(portable_flag_file).touch()
         self.run(cmd="briefcase package windows VisualStudio -p zip", cwd=self.PROJECT_PATH)

--- a/bundle/platforms/windows_briefcase_zip.py
+++ b/bundle/platforms/windows_briefcase_zip.py
@@ -1,0 +1,18 @@
+"""Run adjustments while packaging with briefcase during CI/CD."""
+
+from platforms.windows_briefcase  import WindowsBriefcase
+
+
+class WindowsBriefcaseZip(WindowsBriefcase):
+    """Create portable package for Windows using Briefcase."""
+
+    binary_suffix = ""
+    binary_extension = "zip"
+    binary_platform = "x86_64-Windows"
+
+    def run_framework(self) -> None:
+        self.run(cmd="briefcase create windows VisualStudio", cwd=self.PROJECT_PATH)
+        self._patch_main_cpp()
+        self.run(cmd="briefcase build windows VisualStudio", cwd=self.PROJECT_PATH)
+        self._patch_windows_installer()
+        self.run(cmd="briefcase package windows VisualStudio -p zip", cwd=self.PROJECT_PATH)

--- a/normcap/gui/settings.py
+++ b/normcap/gui/settings.py
@@ -134,7 +134,17 @@ class Settings(QtCore.QSettings):
         parent: Optional[QtCore.QObject] = None,
         init_settings: Optional[dict] = None,
     ) -> None:
-        super().__init__(organization, application=application, parent=parent)
+        from normcap.gui.system_info import is_portable, config_directory
+        if is_portable():
+            ini_file_path = config_directory() / (application + ".ini")
+            ini_file_path = str(ini_file_path.resolve())
+            super().__init__(ini_file_path, QtCore.QSettings.IniFormat)
+        else:
+            super().__init__(
+                organization,
+                application=application,
+                parent=parent,
+            )
         self.setFallbacksEnabled(False)
         self.init_settings: dict = init_settings or {}
         self._prepare_and_sync()

--- a/normcap/gui/system_info.py
+++ b/normcap/gui/system_info.py
@@ -26,6 +26,10 @@ def config_directory() -> Path:
 
     # Windows
     if sys.platform == "win32":
+        if is_portable():
+            data_path = get_package_path() / "data"
+            data_path.mkdir(exist_ok=True)
+            return data_path
         if local_appdata := os.getenv("LOCALAPPDATA"):
             return Path(local_appdata) / postfix
         if appdata := os.getenv("APPDATA"):
@@ -41,6 +45,18 @@ def config_directory() -> Path:
 
 def get_resources_path() -> Path:
     return (Path(__file__).parent.parent / "resources").resolve()
+
+
+def get_package_path() -> Path:
+    return Path(__file__).parent.parent.parent.parent.resolve()
+
+
+@functools.cache
+def is_portable() -> bool:
+    if sys.platform != "win32":
+        return False
+    package_path = get_package_path()
+    return package_path.is_dir() and (package_path / "portable").is_file()
 
 
 def is_briefcase_package() -> bool:


### PR DESCRIPTION
1. support portable package for Windows (fixes #336 )
2. support portable mode on Windows: 
    > If the portable file exists, it is a portable mode. (The portable package will include the file by default)
    > In portable mode, both the settings and the tessdata are read and write from the data directory.

![image](https://github.com/dynobo/normcap/assets/41715438/79d0d7bc-bd5b-4bdc-a6f6-50497c8091f8)
![image](https://github.com/dynobo/normcap/assets/41715438/1c561cb5-9581-42bd-97da-90f48d22e6c2)
