### PR TITLE
Bump Supported Gnome Version for wl-clipboard to 47

### DIFF
--- a/normcap/clipboard/handlers/wlclipboard.py
+++ b/normcap/clipboard/handlers/wlclipboard.py
@@ -43,7 +43,7 @@ def is_compatible() -> bool:
 
     if gnome_version := system_info.get_gnome_version():
         gnome_major = int(gnome_version.split(".")[0])
-        last_working_gnome_version = 44
+        last_working_gnome_version = 47
         if gnome_major > last_working_gnome_version:
             logger.debug("%s is not compatible with Gnome %s", __name__, gnome_version)
             return False


### PR DESCRIPTION
Hi there,

I just tested wl-copy 2.2.1 running on wayland 1.23.1 with Gnome 47.2 and it works just fine. Therefore I suggest bumping the supported Major Version for Supported Gnome Version to 47 for normcap.

In case additional tests are necessary or anything else is needed, feel free to reach out.

Thanks and kind regards