### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -214,14 +214,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.18
+        uses: github/codeql-action/init@v3.28.19
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3.28.18
+        uses: github/codeql-action/autobuild@v3.28.19
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.18
+        uses: github/codeql-action/analyze@v3.28.19
 
   deploy-briefcase:
     name: Briefcase build & draft release


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[v3.28.19](https://github.com/github/codeql-action/releases/tag/v3.28.19)** on 2025-06-03T13:09:00Z
