### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -214,14 +214,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.18
+        uses: github/codeql-action/init@v3.29.0
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3.28.18
+        uses: github/codeql-action/autobuild@v3.29.0
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.18
+        uses: github/codeql-action/analyze@v3.29.0
 
   deploy-briefcase:
     name: Briefcase build & draft release
@@ -299,7 +299,7 @@ jobs:
           verbose: true
           print-hash: true
       - name: Sign published artifacts
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        uses: sigstore/gh-action-sigstore-python@v3.0.1
         with:
           inputs: |
             ./dist/*.tar.gz


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[sigstore/gh-action-sigstore-python](https://github.com/sigstore/gh-action-sigstore-python)** published a new release **[v3.0.1](https://github.com/sigstore/gh-action-sigstore-python/releases/tag/v3.0.1)** on 2025-06-20T18:49:41Z
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[v3.29.0](https://github.com/github/codeql-action/releases/tag/v3.29.0)** on 2025-06-11T19:00:13Z
