### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -157,7 +157,7 @@ jobs:
         shell: bash -l {0}
         run: echo "NOW=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
       - name: Draft internal release
-        uses: ncipollo/release-action@v1.16.0
+        uses: ncipollo/release-action@v1.18.0
         # It's possible, that the run lacks release permissions (e.g. on forks). In
         # this is not crucial, so we just silence the error.
         continue-on-error: true
@@ -214,14 +214,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.18
+        uses: github/codeql-action/init@v3.29.2
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3.28.18
+        uses: github/codeql-action/autobuild@v3.29.2
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.18
+        uses: github/codeql-action/analyze@v3.29.2
 
   deploy-briefcase:
     name: Briefcase build & draft release
@@ -248,7 +248,7 @@ jobs:
         run: uv run poe bundle
       - name: Draft release
         if: github.repository == 'dynobo/normcap'
-        uses: ncipollo/release-action@v1.16.0
+        uses: ncipollo/release-action@v1.18.0
         with:
           body:
             See [CHANGELOG](https://github.com/dynobo/normcap/blob/main/CHANGELOG) for
@@ -299,7 +299,7 @@ jobs:
           verbose: true
           print-hash: true
       - name: Sign published artifacts
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        uses: sigstore/gh-action-sigstore-python@v3.0.1
         with:
           inputs: |
             ./dist/*.tar.gz


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[v3.29.2](https://github.com/github/codeql-action/releases/tag/v3.29.2)** on 2025-06-30T13:01:17Z
* **[sigstore/gh-action-sigstore-python](https://github.com/sigstore/gh-action-sigstore-python)** published a new release **[v3.0.1](https://github.com/sigstore/gh-action-sigstore-python/releases/tag/v3.0.1)** on 2025-06-20T18:49:41Z
* **[ncipollo/release-action](https://github.com/ncipollo/release-action)** published a new release **[v1.18.0](https://github.com/ncipollo/release-action/releases/tag/v1.18.0)** on 2025-06-29T20:34:13Z
