### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -214,14 +214,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5.0.0
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.29.9
+        uses: github/codeql-action/init@v3.29.11
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3.29.9
+        uses: github/codeql-action/autobuild@v3.29.11
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.29.9
+        uses: github/codeql-action/analyze@v3.29.11
 
   deploy-briefcase:
     name: Briefcase build & draft release


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[v3.29.11](https://github.com/github/codeql-action/releases/tag/v3.29.11)** on 2025-08-21T12:48:47Z
