### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -133,7 +133,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5.0.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5.6.0
         with:
           python-version: "3.13"
 
@@ -271,7 +271,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: FTP upload windows package
         if: startsWith(matrix.os, 'windows') && github.repository == 'dynobo/normcap'
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.6
         with:
           server: ${{ secrets.WEBGO_FTP_HOST }}
           username: ${{ secrets.WEBGO_FTP_USER }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[SamKirkland/FTP-Deploy-Action](https://github.com/SamKirkland/FTP-Deploy-Action)** published a new release **[v4.3.6](https://github.com/SamKirkland/FTP-Deploy-Action/releases/tag/v4.3.6)** on 2025-08-26T05:42:50Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.6.0](https://github.com/actions/setup-python/releases/tag/v5.6.0)** on 2025-04-24T02:50:16Z
