### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -222,14 +222,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5.0.0
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.30.5
+        uses: github/codeql-action/init@v4.30.9
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3.30.5
+        uses: github/codeql-action/autobuild@v4.30.9
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.30.5
+        uses: github/codeql-action/analyze@v4.30.9
 
   deploy-briefcase:
     name: Briefcase build & draft release


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[v4.30.9](https://github.com/github/codeql-action/releases/tag/v4.30.9)** on 2025-10-17T15:23:50Z
