### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/action-updater.yaml
+++ b/.github/workflows/action-updater.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -29,9 +29,9 @@ jobs:
         os: [macos-14, macos-15, windows-2022, windows-2025, ubuntu-22.04, ubuntu-24.04]
     steps:
       # Setup environment
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.0
         if: ${{ github.event_name != 'workflow_dispatch' }}
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.0
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
           ref: ${{ inputs.refToBuild }}
@@ -120,7 +120,7 @@ jobs:
       matrix:
         os: [macos-14, macos-15, windows-2025, ubuntu-24.04]
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.0
 
       - uses: ./.github/actions/setup-python-uv
 
@@ -131,7 +131,7 @@ jobs:
     name: Test flatpak build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.0
 
       - uses: actions/setup-python@v6
         with:
@@ -164,7 +164,7 @@ jobs:
       matrix:
         os: [macos-14, macos-15, windows-2025, ubuntu-24.04]
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.0
 
       - uses: ./.github/actions/setup-python-uv
 
@@ -187,7 +187,7 @@ jobs:
     name: Test documentation build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.0
 
       - uses: ./.github/actions/setup-python-uv
 
@@ -200,7 +200,7 @@ jobs:
     if: github.repository_owner == 'dynobo'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.0
       - name: Coveralls Finished
         uses: coverallsapp/github-action@v2.3.6
         with:
@@ -220,16 +220,16 @@ jobs:
         language: ["javascript", "python"]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v6.0.0
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.31.0
+        uses: github/codeql-action/init@v4.31.4
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4.31.0
+        uses: github/codeql-action/autobuild@v4.31.4
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.31.0
+        uses: github/codeql-action/analyze@v4.31.4
 
   deploy-briefcase:
     name: Briefcase build & draft release
@@ -247,7 +247,7 @@ jobs:
       matrix:
         os: [macos-14, macos-15, windows-2025, ubuntu-24.04]
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.0
 
       - uses: ./.github/actions/setup-python-uv
 
@@ -292,7 +292,7 @@ jobs:
       # Used to sign the release's artifacts with sigstore-python.
       id-token: write
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.0
 
       - uses: ./.github/actions/setup-python-uv
 
@@ -314,7 +314,7 @@ jobs:
       && github.repository_owner == 'dynobo'
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.0
 
       - uses: ./.github/actions/setup-python-uv
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v6.0.0](https://github.com/actions/checkout/releases/tag/v6.0.0)** on 2025-11-20T16:24:08Z
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[v4.31.4](https://github.com/github/codeql-action/releases/tag/v4.31.4)** on 2025-11-18T16:14:19Z
