### PR TITLE
fix: hide mouse cursor in Spectacle screenshots on KDE

### DIFF
--- a/normcap/screenshot/handlers/spectacle.py
+++ b/normcap/screenshot/handlers/spectacle.py
@@ -41,6 +41,7 @@ def capture() -> list[QtGui.QImage]:
                 "--fullscreen",
                 "--background",
                 "--nonotify",
+                "--no-decoration",
                 f"--output={image_path.resolve()}",
             ],
             shell=False,


### PR DESCRIPTION
## Problem

On KDE Wayland, Spectacle includes the mouse cursor in screenshots by default. This gives NormCap dirty input — the cursor pixels end up inside the selection area and can confuse OCR.

## Fix

Add `--no-decoration` to the Spectacle arguments. This flag suppresses the cursor overlay without affecting anything else.

One-line change, no side effects.

## Testing

Tested on Fedora 44, KDE Plasma 6.3, Spectacle 24.x, Wayland.