### PR TITLE
replace old standalone "toml" with builtin "tomllib" from standard library

### DIFF
--- a/bundle/l10n.py
+++ b/bundle/l10n.py
@@ -7,9 +7,13 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
-import toml
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 from babel.messages.frontend import CommandLineInterface
 
 LOCALES_PATH = Path(__file__).resolve().parents[1] / "normcap" / "resources" / "locales"
@@ -24,9 +28,9 @@ def _get_version() -> str:
     except Exception:
         print("Could not import __version__. Fallback to pyproject.toml.")  # noqa: T201
         with (Path(__file__).resolve().parents[1] / "pyproject.toml").open(
-            encoding="utf8"
+            "b", encoding="utf8"
         ) as toml_file:
-            pyproject_toml = toml.load(toml_file)
+            pyproject_toml = tomllib.load(toml_file)
         version = pyproject_toml["tool"]["briefcase"]["version"]
 
     return version

--- a/bundle/platforms/utils.py
+++ b/bundle/platforms/utils.py
@@ -10,7 +10,10 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from textwrap import dedent
 
-import toml
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 from retry import retry
 
 
@@ -88,8 +91,8 @@ class BuilderBase(ABC):
         if "--dev" in sys.argv:
             return "0.0.1"
 
-        with Path(self.PYPROJECT_PATH).open(encoding="utf8") as toml_file:
-            pyproject_toml = toml.load(toml_file)
+        with Path(self.PYPROJECT_PATH).open("b", encoding="utf8") as toml_file:
+            pyproject_toml = tomllib.load(toml_file)
         return pyproject_toml["project"]["version"]
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-build = [ "babel", "toml" ]
+build = [ "babel", "tomli"]
 
 [project.urls]
 Homepage = "https://dynobo.github.io/normcap/"
@@ -78,9 +78,8 @@ dev = [
   "rope>=1.7.0",
   "ruff>=0.0.239",
   "tbump>=6.9.0",
-  "toml>=0.10.2",
+  "tomli>=2.0.1; python_version < '3.11'",
   "types-retry>=0.9.9.4",
-  "types-toml>=0.10.8.1",
   "typing-extensions>=4.4.0",
   "poethepoet>=0.29.0",
 ]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,11 @@
 import logging
+import sys
 from pathlib import Path
 
-import toml
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 import normcap
 
@@ -9,8 +13,8 @@ logger = logging.getLogger(__name__)
 
 
 def test_version():
-    with Path("pyproject.toml").open(encoding="utf8") as toml_file:
-        pyproject_toml = toml.load(toml_file)
+    with Path("pyproject.toml").open("b", encoding="utf8") as toml_file:
+        pyproject_toml = tomllib.load(toml_file)
 
     pyproject_version = pyproject_toml["project"]["version"]
     normcap_version = normcap.__version__


### PR DESCRIPTION
Hi,

`tomli` (not `toml`) has been merged in the standard library as `tomllib`

As such, usage of these two external modules `toml` & `tomli` is going steeply down over the years has everyong is using to the built-in lib

a tiny bit more cleanup will be needed once Python 3.10 support is dropped from this project;
but there are here many steps in the right dirrection